### PR TITLE
feat: login server부분 구현 

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
 
 jobs:
   test:

--- a/apps/web/src/app/[locale]/login/aggregate/login.ts
+++ b/apps/web/src/app/[locale]/login/aggregate/login.ts
@@ -9,9 +9,9 @@ export async function authenticate(prevState: any, formData: FormData) {
   try {
     // await signIn('credentials', formData)
     // await signIn('github', formData)
-    await signIn('google', formData)
+    // await signIn('google', formData)
     // await signIn('naver', formData)
-    // await signIn('kakao', formData)
+    await signIn('kakao', formData)
   } catch (error) {
     if (error instanceof AuthError) {
       switch (error.type) {

--- a/apps/web/src/app/[locale]/login/aggregate/login.ts
+++ b/apps/web/src/app/[locale]/login/aggregate/login.ts
@@ -8,8 +8,10 @@ import { signIn } from '@/lib/nextAuth'
 export async function authenticate(prevState: any, formData: FormData) {
   try {
     // await signIn('credentials', formData)
-    await signIn('github', formData)
+    // await signIn('github', formData)
     // await signIn('google', formData)
+    // await signIn('naver', formData)
+    await signIn('kakao', formData)
   } catch (error) {
     if (error instanceof AuthError) {
       switch (error.type) {

--- a/apps/web/src/app/[locale]/login/aggregate/login.ts
+++ b/apps/web/src/app/[locale]/login/aggregate/login.ts
@@ -9,9 +9,9 @@ export async function authenticate(prevState: any, formData: FormData) {
   try {
     // await signIn('credentials', formData)
     // await signIn('github', formData)
-    // await signIn('google', formData)
+    await signIn('google', formData)
     // await signIn('naver', formData)
-    await signIn('kakao', formData)
+    // await signIn('kakao', formData)
   } catch (error) {
     if (error instanceof AuthError) {
       switch (error.type) {

--- a/apps/web/src/app/[locale]/login/page.tsx
+++ b/apps/web/src/app/[locale]/login/page.tsx
@@ -14,8 +14,6 @@ const LoginForm = () => {
   const [errorMessage, dispatch] = useFormState(authenticate, undefined)
   const { data: session } = useLoginSession()
 
-  console.log(session)
-
   return (
     <LogScreen>
       <button type="button" className="w-40 h-10 bg-warning-02-hover">

--- a/apps/web/src/hooks/login/getLoginSession.ts
+++ b/apps/web/src/hooks/login/getLoginSession.ts
@@ -1,4 +1,4 @@
-import { NextAuthSessionResponse } from '@/server/service/auth/AuthService'
+import { NextAuthSessionResponse } from '@/server/service/auth/SignInParams'
 
 import { auth } from '../../lib/nextAuth/auth'
 

--- a/apps/web/src/hooks/login/getLoginSession.ts
+++ b/apps/web/src/hooks/login/getLoginSession.ts
@@ -1,3 +1,5 @@
+import { NextAuthSessionResponse } from '@/server/service/auth/AuthService'
+
 import { auth } from '../../lib/nextAuth/auth'
 
 const getLoginSession = async () => {
@@ -10,7 +12,7 @@ const getLoginSession = async () => {
       picture: session.user.picture,
     } // filter out sensitive data
 
-  return session
+  return session as NextAuthSessionResponse
 }
 
 export default getLoginSession

--- a/apps/web/src/hooks/login/getLoginSession.ts
+++ b/apps/web/src/hooks/login/getLoginSession.ts
@@ -3,6 +3,13 @@ import { auth } from '../../lib/nextAuth/auth'
 const getLoginSession = async () => {
   const session = await auth()
 
+  if (session?.user)
+    session.user = {
+      name: session.user.name,
+      email: session.user.email,
+      picture: session.user.picture,
+    } // filter out sensitive data
+
   return session
 }
 

--- a/apps/web/src/hooks/login/getLoginSession.ts
+++ b/apps/web/src/hooks/login/getLoginSession.ts
@@ -1,4 +1,4 @@
-import { NextAuthSessionResponse } from '@/server/service/auth/SignInParams'
+import { NextAuthSessionResponse } from '@/server/service/auth/type'
 
 import { auth } from '../../lib/nextAuth/auth'
 

--- a/apps/web/src/lib/LibraryClientProvider.tsx
+++ b/apps/web/src/lib/LibraryClientProvider.tsx
@@ -3,7 +3,7 @@
 import { ThemeProvider } from 'next-themes'
 import React, { ReactNode } from 'react'
 
-import { NextAuthSessionResponse } from '@/server/service/auth/SignInParams'
+import { NextAuthSessionResponse } from '@/server/service/auth/type'
 
 import { LoginSessionProvider } from './nextAuth'
 import { useInitTTS } from './voice/tts'

--- a/apps/web/src/lib/LibraryClientProvider.tsx
+++ b/apps/web/src/lib/LibraryClientProvider.tsx
@@ -8,7 +8,6 @@ import { useInitTTS } from './voice/tts'
 
 const LibraryClientProvider = ({ children, session }: any) => {
   useInitTTS()
-
   return (
     <ThemeProvider>
       <LoginSessionProvider session={session}>{children}</LoginSessionProvider>

--- a/apps/web/src/lib/LibraryClientProvider.tsx
+++ b/apps/web/src/lib/LibraryClientProvider.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { ThemeProvider } from 'next-themes'
-import React from 'react'
+import React, { ReactNode } from 'react'
+
+import { NextAuthSessionResponse } from '@/server/service/auth/AuthService'
 
 import { LoginSessionProvider } from './nextAuth'
 import { useInitTTS } from './voice/tts'
 
-const LibraryClientProvider = ({ children, session }: any) => {
+const LibraryClientProvider = ({ children, session }: { children: ReactNode; session: NextAuthSessionResponse }) => {
   useInitTTS()
   return (
     <ThemeProvider>

--- a/apps/web/src/lib/LibraryClientProvider.tsx
+++ b/apps/web/src/lib/LibraryClientProvider.tsx
@@ -3,7 +3,7 @@
 import { ThemeProvider } from 'next-themes'
 import React, { ReactNode } from 'react'
 
-import { NextAuthSessionResponse } from '@/server/service/auth/AuthService'
+import { NextAuthSessionResponse } from '@/server/service/auth/SignInParams'
 
 import { LoginSessionProvider } from './nextAuth'
 import { useInitTTS } from './voice/tts'

--- a/apps/web/src/lib/LibraryProvider.tsx
+++ b/apps/web/src/lib/LibraryProvider.tsx
@@ -9,13 +9,6 @@ import { signOut } from './nextAuth'
 const LibraryProvider = async ({ children }: { children: React.ReactNode }) => {
   const session = await getLoginSession()
 
-  if (session?.user)
-    session.user = {
-      name: session.user.name,
-      email: session.user.email,
-      picture: session.user.picture,
-    } // filter out sensitive data
-
   return (
     <LibraryClientProvider session={session}>
       <JotaiProvider>{children}</JotaiProvider>

--- a/apps/web/src/lib/LibraryProvider.tsx
+++ b/apps/web/src/lib/LibraryProvider.tsx
@@ -1,10 +1,8 @@
-import { redirect } from 'next/navigation'
 import React from 'react'
 
 import getLoginSession from '../hooks/login/getLoginSession'
 import { JotaiProvider } from './jotai'
 import LibraryClientProvider from './LibraryClientProvider'
-import { signOut } from './nextAuth'
 
 const LibraryProvider = async ({ children }: { children: React.ReactNode }) => {
   const session = await getLoginSession()

--- a/apps/web/src/lib/LibraryProvider.tsx
+++ b/apps/web/src/lib/LibraryProvider.tsx
@@ -6,6 +6,7 @@ import LibraryClientProvider from './LibraryClientProvider'
 
 const LibraryProvider = async ({ children }: { children: React.ReactNode }) => {
   const session = await getLoginSession()
+
   if (session?.user)
     session.user = {
       name: session.user.name,

--- a/apps/web/src/lib/LibraryProvider.tsx
+++ b/apps/web/src/lib/LibraryProvider.tsx
@@ -1,8 +1,10 @@
+import { redirect } from 'next/navigation'
 import React from 'react'
 
 import getLoginSession from '../hooks/login/getLoginSession'
 import { JotaiProvider } from './jotai'
 import LibraryClientProvider from './LibraryClientProvider'
+import { signOut } from './nextAuth'
 
 const LibraryProvider = async ({ children }: { children: React.ReactNode }) => {
   const session = await getLoginSession()

--- a/apps/web/src/lib/jwt/jwtMethods.ts
+++ b/apps/web/src/lib/jwt/jwtMethods.ts
@@ -1,15 +1,19 @@
 import jwt, { Jwt } from 'jsonwebtoken'
 
 const jwtMethods = {
-  async encode({ token, secret, maxAge }: { secret?: string; token?: string; maxAge?: number }) {
+  async encode({ token, secret, maxAge }: { secret?: string; token?: any; maxAge?: number }) {
     try {
       const secretValue = secret ?? process.env.AUTH_SECRET
       // `jsonwebtoken`의 `sign` 메소드를 사용하여 토큰 인코딩
+      let maxAgeValue = maxAge
 
-      // @ts-ignore
-      if (token?.exp) delete token.exp
+      if (token.exp) {
+        maxAgeValue = Math.min(maxAgeValue!, Number(token!.exp))
 
-      const encodedToken = jwt.sign(token!, secretValue!, { expiresIn: maxAge })
+        delete token!.exp
+      }
+
+      const encodedToken = jwt.sign(token!, secretValue!, { expiresIn: maxAgeValue })
 
       return encodedToken
     } catch (error) {

--- a/apps/web/src/lib/jwt/jwtMethods.ts
+++ b/apps/web/src/lib/jwt/jwtMethods.ts
@@ -1,13 +1,15 @@
-import jwt, { Jwt } from 'jsonwebtoken'
+import jwt, { Jwt, JwtPayload } from 'jsonwebtoken'
+
+import { JWT } from '@/server/service/auth/type'
 
 const jwtMethods = {
-  async encode({ token, secret, maxAge }: { secret?: string; token?: any; maxAge?: number }) {
+  async encode({ token, secret, maxAge }: { secret?: string; token?: JWT & JwtPayload; maxAge?: number }) {
     try {
       const secretValue = secret ?? process.env.AUTH_SECRET
       // `jsonwebtoken`의 `sign` 메소드를 사용하여 토큰 인코딩
       let maxAgeValue = maxAge
 
-      if (token.exp) {
+      if (token!.exp) {
         maxAgeValue = Math.min(maxAgeValue!, Number(token!.exp))
 
         delete token!.exp

--- a/apps/web/src/lib/jwt/jwtMethods.ts
+++ b/apps/web/src/lib/jwt/jwtMethods.ts
@@ -26,10 +26,8 @@ const jwtMethods = {
       const secretValue = secret ?? process.env.AUTH_SECRET
       const decoded = jwt.verify(token!, secretValue!)
 
-      console.log('decoded!', decoded)
       return decoded
     } catch (error) {
-      console.error('Error decoding token:', error)
       // 디코딩 실패 시 null 반환
       return null
     }

--- a/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
+++ b/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
-import React, { useEffect, useState } from 'react'
+import React, { ReactNode, useEffect, useState } from 'react'
 
-const LoginSessionProvider = ({ children, session }: any) => {
+import { NextAuthSessionResponse } from '@/server/service/auth/AuthService'
+
+const LoginSessionProvider = ({ children, session }: { children: ReactNode; session: NextAuthSessionResponse }) => {
   const [sessionRefetchInterval, setSessionRefetchInterval] = useState(10000)
 
   useEffect(() => {

--- a/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
+++ b/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
@@ -9,7 +9,7 @@ const LoginSessionProvider = ({ children, session }: any) => {
   useEffect(() => {
     if (session) {
       const nowTime = Math.round(Date.now() / 1000)
-      const timeRemaining = (session.expires_at as number) - 5 * 60 - nowTime
+      const timeRemaining = (session.expiresAt as number) - 5 * 60 - nowTime
 
       setSessionRefetchInterval(timeRemaining > 0 ? timeRemaining : 0)
     }

--- a/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
+++ b/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
@@ -3,7 +3,7 @@
 import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
 import React, { ReactNode, useEffect, useState } from 'react'
 
-import { NextAuthSessionResponse } from '@/server/service/auth/AuthService'
+import { NextAuthSessionResponse } from '@/server/service/auth/SignInParams'
 
 const LoginSessionProvider = ({ children, session }: { children: ReactNode; session: NextAuthSessionResponse }) => {
   const [sessionRefetchInterval, setSessionRefetchInterval] = useState(10000)

--- a/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
+++ b/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
@@ -1,8 +1,24 @@
+'use client'
+
 import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 const LoginSessionProvider = ({ children, session }: any) => {
-  return <NextAuthSessionProvider session={session}>{children}</NextAuthSessionProvider>
+  const [sessionRefetchInterval, setSessionRefetchInterval] = useState(10000)
+
+  useEffect(() => {
+    if (session) {
+      const nowTime = Math.round(Date.now() / 1000)
+      const timeRemaining = (session.accessTokenExpires as number) - 7 * 60 - nowTime
+      setSessionRefetchInterval(timeRemaining > 0 ? timeRemaining : 0)
+    }
+  }, [session, setSessionRefetchInterval])
+
+  return (
+    <NextAuthSessionProvider refetchInterval={sessionRefetchInterval} session={session}>
+      {children}
+    </NextAuthSessionProvider>
+  )
 }
 
 export default LoginSessionProvider

--- a/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
+++ b/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
@@ -9,7 +9,8 @@ const LoginSessionProvider = ({ children, session }: any) => {
   useEffect(() => {
     if (session) {
       const nowTime = Math.round(Date.now() / 1000)
-      const timeRemaining = (session.accessTokenExpires as number) - 7 * 60 - nowTime
+      const timeRemaining = (session.expires_at as number) - 5 * 60 - nowTime
+
       setSessionRefetchInterval(timeRemaining > 0 ? timeRemaining : 0)
     }
   }, [session, setSessionRefetchInterval])

--- a/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
+++ b/apps/web/src/lib/nextAuth/LoginSessionProvider.tsx
@@ -3,7 +3,7 @@
 import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
 import React, { ReactNode, useEffect, useState } from 'react'
 
-import { NextAuthSessionResponse } from '@/server/service/auth/SignInParams'
+import { NextAuthSessionResponse } from '@/server/service/auth/type'
 
 const LoginSessionProvider = ({ children, session }: { children: ReactNode; session: NextAuthSessionResponse }) => {
   const [sessionRefetchInterval, setSessionRefetchInterval] = useState(10000)

--- a/apps/web/src/lib/nextAuth/auth.config.ts
+++ b/apps/web/src/lib/nextAuth/auth.config.ts
@@ -1,5 +1,5 @@
 import bcrypt from 'bcrypt'
-import type { NextAuthConfig } from 'next-auth'
+import { JwtPayload } from 'jsonwebtoken'
 import Credentials from 'next-auth/providers/credentials'
 import GithubProvider from 'next-auth/providers/github'
 import GoogleProvider from 'next-auth/providers/google'
@@ -9,6 +9,7 @@ import { z } from 'zod'
 
 import { AuthRepository } from '@/server/repository'
 import AuthService from '@/server/service/auth/AuthService'
+import { JWT } from '@/server/service/auth/type'
 
 import jwtMethods from '../jwt/jwtMethods'
 
@@ -29,11 +30,11 @@ export const authConfig = {
   },
 
   jwt: {
-    async encode({ token, secret, maxAge }) {
-      return jwtMethods.encode({ token: token as unknown as string, secret, maxAge })
+    async encode({ token, secret, maxAge }: { token: JWT & JwtPayload; secret: string; maxAge: number }) {
+      return jwtMethods.encode({ token, secret, maxAge })
     },
-    async decode({ token, secret }) {
-      return jwtMethods.decode({ token, secret })
+    async decode({ token, secret }: { token: string; secret: string }) {
+      return jwtMethods.decode({ token, secret }) as Promise<string>
     },
   },
 
@@ -83,4 +84,4 @@ export const authConfig = {
       },
     }),
   ],
-} as NextAuthConfig
+}

--- a/apps/web/src/lib/nextAuth/auth.config.ts
+++ b/apps/web/src/lib/nextAuth/auth.config.ts
@@ -45,6 +45,7 @@ export const authConfig = {
     GoogleProvider({
       clientId: process.env.GOOGLE_ID,
       clientSecret: process.env.GOOGLE_SECRET,
+      authorization: { params: { access_type: 'offline', prompt: 'consent' } },
     }),
     NaverProvider({
       clientId: process.env.NAVER_ID,

--- a/apps/web/src/lib/nextAuth/auth.config.ts
+++ b/apps/web/src/lib/nextAuth/auth.config.ts
@@ -25,7 +25,7 @@ export const authConfig = {
 
   session: {
     strategy: 'jwt',
-    maxAge: 60000,
+    maxAge: 5 * 24 * 60 * 60, // cookie 수명 - 5일
   },
 
   jwt: {

--- a/apps/web/src/lib/nextAuth/auth.config.ts
+++ b/apps/web/src/lib/nextAuth/auth.config.ts
@@ -3,6 +3,8 @@ import type { NextAuthConfig } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import GithubProvider from 'next-auth/providers/github'
 import GoogleProvider from 'next-auth/providers/google'
+import KakaoProvider from 'next-auth/providers/kakao'
+import NaverProvider from 'next-auth/providers/naver'
 import { z } from 'zod'
 
 import { AuthRepository } from '@/server/repository'
@@ -43,6 +45,14 @@ export const authConfig = {
     GoogleProvider({
       clientId: process.env.GOOGLE_ID,
       clientSecret: process.env.GOOGLE_SECRET,
+    }),
+    NaverProvider({
+      clientId: process.env.NAVER_ID,
+      clientSecret: process.env.NAVER_SECRET,
+    }),
+    KakaoProvider({
+      clientId: process.env.KAKAO_ID,
+      clientSecret: process.env.KAKAO_SECRET,
     }),
 
     /** FIXME

--- a/apps/web/src/lib/nextAuth/auth.config.ts
+++ b/apps/web/src/lib/nextAuth/auth.config.ts
@@ -25,7 +25,7 @@ export const authConfig = {
 
   session: {
     strategy: 'jwt',
-    maxAge: 100000,
+    maxAge: 60000,
   },
 
   jwt: {

--- a/apps/web/src/lib/supabase/type.ts
+++ b/apps/web/src/lib/supabase/type.ts
@@ -1,1 +1,3 @@
-export default interface Database {}
+type Database = any
+
+export default Database

--- a/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
+++ b/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
@@ -15,6 +15,7 @@ const columnNames = [
   'session_state',
   'oauth_token_secret',
   'oauth_token',
+
   'id',
   'userId',
 ]

--- a/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
+++ b/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
@@ -26,6 +26,9 @@ const supabaseAdapterWrapper = () => {
       const { id } = (await supaAdapter.createUser(clonedUser)) as { id: string }
 
       account.userId = id
+
+      if (account.expires_in) account.expires_in = undefined
+
       await supaAdapter.linkAccount(account)
 
       return true

--- a/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
+++ b/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
@@ -34,8 +34,6 @@ const supabaseAdapterWrapper = () => {
   })
 
   const updateAccount = async ({ newAccount }: any) => {
-    console.log(newAccount, 'ttt')
-
     const account: { [key in string]: number | string } = {}
 
     // 특정 oauth의 경우 필요없는 key 값을 보내기도 함 (ex-google)

--- a/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
+++ b/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
@@ -42,7 +42,9 @@ const supabaseAdapterWrapper = () => {
 
       const { id } = (await supaAdapter.createUser(clonedUser)) as { id: string }
 
-      const newAccount: { [key in string]: number | string } = { userId: id }
+      account.userId = id
+
+      const newAccount: { [key in string]: number | string } = {}
 
       // 특정 oauth의 경우 필요없는 key 값을 보내기도 함 (ex-google)
       columnNames.forEach((name) => {

--- a/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
+++ b/apps/web/src/server/repository/AuthRepository/AuthAdapter/SupabaseAdapter.ts
@@ -2,6 +2,23 @@ import { SupabaseAdapter } from '@auth/supabase-adapter'
 
 import { SUPABASE_KEY, SUPABASE_URL } from '@/lib/supabase/supabase'
 
+const columnNames = [
+  'expires_at',
+  'type',
+  'provider',
+  'providerAccountId',
+  'refresh_token',
+  'access_token',
+  'token_type',
+  'scope',
+  'id_token',
+  'session_state',
+  'oauth_token_secret',
+  'oauth_token',
+  'id',
+  'userId',
+]
+
 const supabaseAdapterWrapper = () => {
   const supaAdapter = SupabaseAdapter({
     url: SUPABASE_URL,
@@ -25,11 +42,14 @@ const supabaseAdapterWrapper = () => {
 
       const { id } = (await supaAdapter.createUser(clonedUser)) as { id: string }
 
-      account.userId = id
+      const newAccount: { [key in string]: number | string } = { userId: id }
 
-      if (account.expires_in) account.expires_in = undefined
+      // 특정 oauth의 경우 필요없는 key 값을 보내기도 함 (ex-google)
+      columnNames.forEach((name) => {
+        newAccount[name] = account[name]
+      })
 
-      await supaAdapter.linkAccount(account)
+      await supaAdapter.linkAccount(newAccount)
 
       return true
     }

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -72,7 +72,7 @@ class AuthService {
       }
     }
 
-    console.log(`login ${user.id}, ${user.name} ${user.email}`)
+    // console.log(`login ${user.id}, ${user.name} ${user.email}`)
     return true
   }
 
@@ -101,7 +101,7 @@ class AuthService {
 
     const shouldRefreshTime = (token.expires_at as number) - 7 * 60 - nowTime
 
-    console.log(shouldRefreshTime, 'ref', token.provider)
+    // console.log(shouldRefreshTime, 'ref', token.provider)
 
     if (shouldRefreshTime > 0) {
       return token

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -54,7 +54,7 @@ class AuthService {
   }
 
   signIn = async ({ user, account }: SignInParams): Promise<boolean> => {
-    if (account?.provider && ['github', 'google'].includes(account.provider)) {
+    if (account?.provider && ['github', 'google', 'naver', 'kakao'].includes(account.provider)) {
       try {
         return await this.authRepository.findOrCreateUser({ user, account })
       } catch (e) {

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -45,7 +45,7 @@ class AuthService {
           client_id: process.env.GOOGLE_ID!,
           client_secret: process.env.GOOGLE_SECRET!,
           grant_type: 'refresh_token',
-          refresh_token: token.refresh_token,
+          refresh_token: token.refreshToken,
         }),
         method: 'POST',
       })
@@ -54,13 +54,16 @@ class AuthService {
 
       if (!response.ok) throw tokens
 
+      console.log('refresh !!!', tokens)
+
       return {
         ...token, // Keep the previous token properties
         access_token: tokens.access_token,
-        accessTokenExpires: tokens.expires_at,
+        expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+
         // Fall back to old refresh token, but note that
         // many providers may only allow using a refresh token once.
-        refresh_token: tokens.refresh_token ?? token.refresh_token,
+        refreshToken: tokens.refresh_token ?? token.refreshToken,
       }
     } catch (err) {
       console.log(`token error: ${JSON.stringify(err)}`)
@@ -99,7 +102,7 @@ class AuthService {
       return {
         ...token,
         accessToken: account.access_token,
-        accessTokenExpires: account.expires_at,
+        expires_at: account.expires_at ?? Math.floor(Date.now() / 1000 + (account?.expires_in ?? 60000)),
         refreshToken: account.refresh_token,
         user,
         userId: user.id,
@@ -107,7 +110,7 @@ class AuthService {
       }
     }
 
-    const shouldRefreshTime = (token.accessTokenExpires as number) - 70 * 60 - nowTime
+    const shouldRefreshTime = (token.expires_at as number) - 70 * 60 - nowTime
 
     console.log(shouldRefreshTime, 'ref')
 

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -49,7 +49,7 @@ class AuthService {
           ...token.account,
           refresh_token: refreshToken.refreshToken,
           access_token: refreshToken.accessToken,
-          expires_at: refreshToken.expires_at,
+          expires_at: refreshToken.expiresAt,
         },
       })
 
@@ -91,7 +91,7 @@ class AuthService {
       return {
         ...token,
         accessToken: account.access_token!,
-        expires_at: account.expires_at ?? Math.floor(Date.now() / 1000 + (account?.expires_in ?? 60000)),
+        expiresAt: account.expires_at ?? Math.floor(Date.now() / 1000 + (account?.expires_in ?? 60000)),
         refreshToken: account.refresh_token,
         user,
         userId: user.id,
@@ -100,7 +100,7 @@ class AuthService {
       }
     }
 
-    const shouldRefreshTime = token.expires_at - 7 * 60 - nowTime
+    const shouldRefreshTime = token.expiresAt - 7 * 60 - nowTime
 
     // console.log(shouldRefreshTime, 'ref', token.provider)
 
@@ -114,10 +114,10 @@ class AuthService {
   session = async ({ session: _session, token }: SessionParams) => {
     return {
       ..._session,
-      user: token.user as User,
+      user: token.user,
       accessToken: token.accessToken,
       error: token.error,
-      expires_at: token.expires_at,
+      expiresAt: token.expiresAt,
       provider: token.provider,
     }
   }

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -38,6 +38,8 @@ class AuthService {
   }
 
   refreshAccessToken = async (token: JWT, user: User, nowTime: number): Promise<JWT> => {
+    const { provider } = token
+
     try {
       const response = await fetch('https://oauth2.googleapis.com/token', {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -54,11 +56,11 @@ class AuthService {
 
       if (!response.ok) throw tokens
 
-      console.log('refresh !!!', tokens)
+      console.log('refresh !!!', token, tokens)
 
       return {
         ...token, // Keep the previous token properties
-        access_token: tokens.access_token,
+        accessToken: tokens.access_token,
         expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
 
         // Fall back to old refresh token, but note that

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -39,7 +39,27 @@ class AuthService {
 
   refreshAccessToken = async (token: JWT, user: User, nowTime: number): Promise<JWT> => {
     try {
-      // Refresh logic here
+      const url = 'https://oauth2.googleapis.com/token'
+      const clientId = process.env.GOOGLE_ID
+      const clientSecret = process.env.GOOGLE_SECRET
+      const { refreshToken } = token
+
+      console.log('TEST!', token, refreshToken)
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: `client_id=${clientId}&client_secret=${clientSecret}&refresh_token=${refreshToken}&grant_type=refresh_token`,
+      })
+
+      const refreshedTokens = await response.json()
+
+      if (!response.ok) {
+        throw refreshedTokens
+      }
+
       return {
         ...token,
         exp: Math.round(Date.now() / 1000) + 100000,

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -1,44 +1,10 @@
 /* eslint-disable camelcase */
-import { NextRequest } from 'next/server'
 import { Provider } from 'next-auth/providers'
-import { CredentialInput } from 'next-auth/providers/credentials'
-import { Account, Profile, Session, User } from 'next-auth/types'
 
 import { AuthRepository } from '@/server/repository'
 
 import refreshTokenFactory from './refresh/refreshTokenFactory'
-import { JWT } from './type'
-
-export type SignInParams = {
-  user: User
-  account: Account | undefined
-  profile: Profile | undefined
-  email: string | undefined
-  credentials: Record<string, CredentialInput> | undefined
-}
-
-export type AuthorizedParams = {
-  auth: Session | null
-  request: NextRequest
-}
-
-export type JWTParams = {
-  token: JWT
-  account?: Account | null
-  user?: User | null
-}
-
-export type SessionParams = {
-  session: Session
-  token: JWT
-}
-
-export type NextAuthSessionResponse = Session & {
-  user: User | null
-  error?: string
-  expiresAt: number
-  provider: Account['provider']
-}
+import { AuthorizedParams, JWT, JWTParams, NextAuthSessionResponse, SessionParams, SignInParams } from './type'
 
 class AuthService {
   private authRepository: typeof AuthRepository

--- a/apps/web/src/server/service/auth/AuthService.ts
+++ b/apps/web/src/server/service/auth/AuthService.ts
@@ -9,7 +9,7 @@ import { AuthRepository } from '@/server/repository'
 import refreshTokenFactory from './refresh/refreshTokenFactory'
 import { JWT } from './type'
 
-type SignInParams = {
+export type SignInParams = {
   user: User
   account: Account | undefined
   profile: Profile | undefined
@@ -17,20 +17,27 @@ type SignInParams = {
   credentials: Record<string, CredentialInput> | undefined
 }
 
-type AuthorizedParams = {
+export type AuthorizedParams = {
   auth: Session | null
   request: NextRequest
 }
 
-type JWTParams = {
+export type JWTParams = {
   token: JWT
   account?: Account | null
   user?: User | null
 }
 
-type SessionParams = {
+export type SessionParams = {
   session: Session
   token: JWT
+}
+
+export type NextAuthSessionResponse = Session & {
+  user: User | null
+  error?: string
+  expiresAt: number
+  provider: Account['provider']
 }
 
 class AuthService {
@@ -111,11 +118,10 @@ class AuthService {
     return this.refreshAccessToken(token)
   }
 
-  session = async ({ session: _session, token }: SessionParams) => {
+  session = async ({ session: _session, token }: SessionParams): Promise<NextAuthSessionResponse> => {
     return {
       ..._session,
       user: token.user,
-      accessToken: token.accessToken,
       error: token.error,
       expiresAt: token.expiresAt,
       provider: token.provider,
@@ -124,5 +130,4 @@ class AuthService {
 }
 
 const AuthServiceInstance = new AuthService(AuthRepository)
-
 export default AuthServiceInstance

--- a/apps/web/src/server/service/auth/refresh/githubRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/githubRefreshToken.ts
@@ -1,0 +1,30 @@
+type JWT = any
+
+export default async function kakaoRefreshToken({ token }: JWT) {
+  const response = await fetch('https://github.com/login/oauth/access_token', {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: process.env.GITHUB_ID!,
+      client_secret: process.env.GITHUB_SECRET!,
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken,
+    }),
+    method: 'POST',
+  })
+
+  const tokens = await response.json()
+
+  if (!response.ok) throw tokens
+
+  console.log('refresh !!!', token, tokens)
+
+  return {
+    ...token, // Keep the previous token properties
+    accessToken: tokens.access_token,
+    expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+
+    // Fall back to old refresh token, but note that
+    // many providers may only allow using a refresh token once.
+    refreshToken: tokens.refresh_token ?? token.refreshToken,
+  }
+}

--- a/apps/web/src/server/service/auth/refresh/githubRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/githubRefreshToken.ts
@@ -1,30 +1,8 @@
 type JWT = any
 
-export default async function kakaoRefreshToken({ token }: JWT) {
-  const response = await fetch('https://github.com/login/oauth/access_token', {
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: process.env.GITHUB_ID!,
-      client_secret: process.env.GITHUB_SECRET!,
-      grant_type: 'refresh_token',
-      refresh_token: token.refreshToken,
-    }),
-    method: 'POST',
-  })
-
-  const tokens = await response.json()
-
-  if (!response.ok) throw tokens
-
-  console.log('refresh !!!', token, tokens)
-
-  return {
-    ...token, // Keep the previous token properties
-    accessToken: tokens.access_token,
-    expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
-
-    // Fall back to old refresh token, but note that
-    // many providers may only allow using a refresh token once.
-    refreshToken: tokens.refresh_token ?? token.refreshToken,
-  }
+/*
+ * github는 refresh token이 없다
+ */
+export default async function githubfreshToken({ token }: JWT) {
+  throw token
 }

--- a/apps/web/src/server/service/auth/refresh/githubRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/githubRefreshToken.ts
@@ -1,8 +1,8 @@
-type JWT = any
+import { JWT } from '../type'
 
 /*
  * github는 refresh token이 없다
  */
-export default async function githubfreshToken({ token }: JWT) {
+export default async function githubfreshToken({ token }: { token: JWT }) {
   throw token
 }

--- a/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
@@ -16,8 +16,6 @@ export default async function googleRefreshToken({ token }: JWT) {
 
   if (!response.ok) throw tokens
 
-  console.log('refresh !!!', token, tokens)
-
   return {
     ...token, // Keep the previous token properties
     accessToken: tokens.access_token,

--- a/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
@@ -1,0 +1,30 @@
+type JWT = any
+
+export default async function googleRefreshToken({ token }: JWT) {
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: process.env.GOOGLE_ID!,
+      client_secret: process.env.GOOGLE_SECRET!,
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken,
+    }),
+    method: 'POST',
+  })
+
+  const tokens = await response.json()
+
+  if (!response.ok) throw tokens
+
+  console.log('refresh !!!', token, tokens)
+
+  return {
+    ...token, // Keep the previous token properties
+    accessToken: tokens.access_token,
+    expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+
+    // Fall back to old refresh token, but note that
+    // many providers may only allow using a refresh token once.
+    refreshToken: tokens.refresh_token ?? token.refreshToken,
+  }
+}

--- a/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
@@ -1,13 +1,13 @@
-type JWT = any
+import { JWT } from '../type'
 
-export default async function googleRefreshToken({ token }: JWT) {
+export default async function googleRefreshToken({ token }: { token: JWT }) {
   const response = await fetch('https://oauth2.googleapis.com/token', {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       client_id: process.env.GOOGLE_ID!,
       client_secret: process.env.GOOGLE_SECRET!,
       grant_type: 'refresh_token',
-      refresh_token: token.refreshToken,
+      refresh_token: token.refreshToken!,
     }),
     method: 'POST',
   })

--- a/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/googleRefreshToken.ts
@@ -19,7 +19,7 @@ export default async function googleRefreshToken({ token }: { token: JWT }) {
   return {
     ...token, // Keep the previous token properties
     accessToken: tokens.access_token,
-    expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+    expiresAt: Math.floor(Date.now() / 1000 + tokens.expires_in),
 
     // Fall back to old refresh token, but note that
     // many providers may only allow using a refresh token once.

--- a/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
@@ -1,0 +1,30 @@
+type JWT = any
+
+export default async function kakaoRefreshToken({ token }: JWT) {
+  const response = await fetch('https://kauth.kakao.com/oauth/token', {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: process.env.KAKAO_ID!,
+      client_secret: process.env.KAKAO_SECRET!,
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken,
+    }),
+    method: 'POST',
+  })
+
+  const tokens = await response.json()
+
+  if (!response.ok) throw tokens
+
+  console.log('refresh !!!', token, tokens)
+
+  return {
+    ...token, // Keep the previous token properties
+    accessToken: tokens.access_token,
+    expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+
+    // Fall back to old refresh token, but note that
+    // many providers may only allow using a refresh token once.
+    refreshToken: tokens.refresh_token ?? token.refreshToken,
+  }
+}

--- a/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
@@ -1,13 +1,13 @@
-type JWT = any
+import { JWT } from '../type'
 
-export default async function kakaoRefreshToken({ token }: JWT) {
+export default async function kakaoRefreshToken({ token }: { token: JWT }) {
   const response = await fetch('https://kauth.kakao.com/oauth/token', {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       client_id: process.env.KAKAO_ID!,
       client_secret: process.env.KAKAO_SECRET!,
       grant_type: 'refresh_token',
-      refresh_token: token.refreshToken,
+      refresh_token: token.refreshToken!,
     }),
     method: 'POST',
   })

--- a/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
@@ -19,7 +19,7 @@ export default async function kakaoRefreshToken({ token }: { token: JWT }) {
   return {
     ...token, // Keep the previous token properties
     accessToken: tokens.access_token,
-    expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+    expiresAt: Math.floor(Date.now() / 1000 + tokens.expires_in),
 
     // Fall back to old refresh token, but note that
     // many providers may only allow using a refresh token once.

--- a/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
+++ b/apps/web/src/server/service/auth/refresh/kakaoRefreshToken.ts
@@ -16,8 +16,6 @@ export default async function kakaoRefreshToken({ token }: JWT) {
 
   if (!response.ok) throw tokens
 
-  console.log('refresh !!!', token, tokens)
-
   return {
     ...token, // Keep the previous token properties
     accessToken: tokens.access_token,

--- a/apps/web/src/server/service/auth/refresh/refreshTokenFactory.ts
+++ b/apps/web/src/server/service/auth/refresh/refreshTokenFactory.ts
@@ -1,8 +1,7 @@
+import { JWT } from '../type'
 import githubRefreshToken from './githubRefreshToken'
 import googleRefreshToken from './googleRefreshToken'
 import kakaoRefreshToken from './kakaoRefreshToken'
-
-type JWT = any
 
 export default async function refreshTokenFactory(token: JWT) {
   const { provider } = token

--- a/apps/web/src/server/service/auth/refresh/refreshTokenFactory.ts
+++ b/apps/web/src/server/service/auth/refresh/refreshTokenFactory.ts
@@ -1,0 +1,20 @@
+import githubRefreshToken from './githubRefreshToken'
+import googleRefreshToken from './googleRefreshToken'
+import kakaoRefreshToken from './kakaoRefreshToken'
+
+type JWT = any
+
+export default async function refreshTokenFactory(token: JWT) {
+  const { provider } = token
+
+  switch (provider) {
+    case 'google':
+      return googleRefreshToken({ token })
+    case 'kakao':
+      return kakaoRefreshToken({ token })
+    case 'github':
+      return githubRefreshToken({ token })
+    default:
+      throw new Error(`Unsupported provider: ${provider}`)
+  }
+}

--- a/apps/web/src/server/service/auth/type.ts
+++ b/apps/web/src/server/service/auth/type.ts
@@ -1,4 +1,6 @@
-import { Account, User } from 'next-auth'
+import { NextRequest } from 'next/server'
+import { CredentialInput } from 'next-auth/providers/credentials'
+import { Account, Profile, Session, User } from 'next-auth/types'
 
 export type JWT = {
   user: User
@@ -10,4 +12,35 @@ export type JWT = {
   accessToken: string
   refreshToken?: string // 깃허브는 존재하지 않음
   provider: 'github' | 'kakao' | 'google' | 'naver'
+}
+
+export type SignInParams = {
+  user: User
+  account: Account | undefined
+  profile: Profile | undefined
+  email: string | undefined
+  credentials: Record<string, CredentialInput> | undefined
+}
+
+export type AuthorizedParams = {
+  auth: Session | null
+  request: NextRequest
+}
+
+export type JWTParams = {
+  token: JWT
+  account?: Account | null
+  user?: User | null
+}
+
+export type SessionParams = {
+  session: Session
+  token: JWT
+}
+
+export type NextAuthSessionResponse = Session & {
+  user: User | null
+  error?: string
+  expiresAt: number
+  provider: Account['provider']
 }

--- a/apps/web/src/server/service/auth/type.ts
+++ b/apps/web/src/server/service/auth/type.ts
@@ -1,0 +1,15 @@
+import { Account, User } from 'next-auth'
+
+export type JWT = {
+  user: User
+  account: Account
+  error?: string
+
+  userId: string
+
+  // eslint-disable-next-line camelcase
+  expires_at: number
+  accessToken: string
+  refreshToken?: string // 깃허브는 존재하지 않음
+  provider: 'github' | 'kakao' | 'google' | 'naver'
+}

--- a/apps/web/src/server/service/auth/type.ts
+++ b/apps/web/src/server/service/auth/type.ts
@@ -6,9 +6,7 @@ export type JWT = {
   error?: string
 
   userId: string
-
-  // eslint-disable-next-line camelcase
-  expires_at: number
+  expiresAt: number
   accessToken: string
   refreshToken?: string // 깃허브는 존재하지 않음
   provider: 'github' | 'kakao' | 'google' | 'naver'

--- a/packages/shared/index.tsx
+++ b/packages/shared/index.tsx
@@ -1,7 +1,7 @@
+import generateLocaleFiles from 'i18n/generate-locale-files'
 
 export * from './src/designVariables'
 export * from './src/utils'
-import generateLocaleFiles from 'i18n/generate-locale-files'
 
 /*
 export * from './src/hook'

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,11 @@
     "GITHUB_ID",
     "GITHUB_SECRET",
     "GOOGLE_ID",
-    "GOOGLE_SECRET"
+    "GOOGLE_SECRET",
+    "NAVER_ID",
+    "NAVER_SECRET",
+    "KAKAO_ID",
+    "KAKAO_SECRET"
   ],
 
   "pipeline": {


### PR DESCRIPTION
naver login은 auth 2.0 스펙을 준수하지 않아서 next-auth로 바로 구현은 불가능함

https://github.com/nextauthjs/next-auth/discussions/9313

필요시 따로 구현해야할듯..


## 구현 내용
```jsx
refreshAccessToken = async (token: JWT, user: User, nowTime: number): Promise<JWT> => {
    try {
      const refreshToken = await refreshTokenFactory(token)

      this.authRepository.updateAccount({
        newAccount: {
          ...token.account,
          refresh_token: refreshToken.refreshToken,
          access_token: refreshToken.accessToken,
          expires_at: refreshToken.expires_at,
        },
      })

      return refreshToken
    } catch (err) {
      console.log(`token error: ${JSON.stringify(err)}`)
      return {
        ...token,
        error: 'RefreshAccessTokenError',
      }
    }
  }
```

1. kakao 로그인 서버단 구현
2. github 로그인 서버단 구현
3. google 로그인 서버단 구현

4. refresh token logic 구현
5. refresh시 db의 token 정보도 업데이트 하도록 구현

6. 클라이언트에서 acess token의 유효 시간 7분 전에 refresh 해오는 로직을 구현함 
(캐싱 처리는 안했는데 한다고 치면 다음 커밋에서 작업할듯)

## 논의하면 좋을점

1. 지금은 단순히 토큰을 받아와서 저장하기만 하는데 
보안을 위해서 뭔가 추가 로직을 넣어야할지??

2. 엑세스 토큰의 유효시간은 따로 조절하지 않고 리소스 소유자의 유효기간을 그대로 사용하는데
따로 제한할지? (2시간 등등)

## 기타 tmi 

깃허브 로그인의 경우 refresh token을 제공하지 않는듯..? 

